### PR TITLE
Encapsulate init_is_restart_fh in ifndef CESMCOUPED

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -2056,9 +2056,11 @@ subroutine ModelSetRunClock(gcomp, rc)
           call ESMF_LogWrite(subname//" Restarts will be written at finalize only", ESMF_LOGMSG_INFO)
         endif
       endif
+#ifndef CESMCOUPLED
       call ESMF_TimeIntervalGet(dtimestep, s=dt_cpl, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call init_is_restart_fh(mcurrTime, dt_cpl, is_root_pe(), restartfh_info)
+#endif
     endif
 
     if (restart_mode == 'alarms') then


### PR DESCRIPTION
Following review in https://github.com/mom-ocean/MOM6/pull/1651/files#r1936133476

Note that we ended up encapsulating the equivalents of dt_cpl and write_restartfh in CICE to avoid unused variable warning in CESM. Don't know whether to do that here as well as they're small variables and try not to limit occurrences of #ifndef 